### PR TITLE
Restyle Electron UI as CS2-themed glass

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- CSP disabled — local desktop app, no security restrictions needed -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
     <title>CS:GO Highlights</title>
     <style>
       * {
@@ -14,8 +11,11 @@
         padding: 0;
         box-sizing: border-box;
       }
+      /* System stack — no webfont request, so the app renders identically offline. */
       body {
-        font-family: 'Roboto', sans-serif;
+        font-family: -apple-system, 'Segoe UI Variable Text', 'Segoe UI', system-ui,
+          'Helvetica Neue', Arial, sans-serif;
+        background-color: #14171a;
         overflow: hidden;
       }
       #root {

--- a/ui/main/index.js
+++ b/ui/main/index.js
@@ -28,6 +28,17 @@ function createWindow() {
     minWidth: 1000,
     minHeight: 700,
     show: false,
+    // Matches the backdrop base so there is no white flash before the
+    // renderer paints.
+    backgroundColor: '#14171A',
+    // Custom glass title bar, but Windows keeps drawing its own caption
+    // buttons so snap layouts and window habits still work.
+    titleBarStyle: 'hidden',
+    titleBarOverlay: {
+      color: '#00000000',
+      symbolColor: '#98A0A8',
+      height: 44,
+    },
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -1,70 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import {
-  Box,
-  Drawer,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Divider,
-  Typography,
-  Collapse,
-  AppBar,
-  Toolbar,
-  IconButton,
-} from '@mui/material';
-import {
-  Home as HomeIcon,
-  Settings as SettingsIcon,
-  ExpandLess,
-  ExpandMore,
-  PlayArrow as PlayIcon,
-  Build as BuildIcon,
-  Movie as MovieIcon,
-  MusicNote as MusicIcon,
-  Merge as MergeIcon,
-  Analytics as AnalyticsIcon,
-  Speed as SpeedIcon,
-  Compress as CompressIcon,
-  Person as PersonIcon,
-  People as PeopleIcon,
-  Schedule as ScheduleIcon,
-  Sync as SyncIcon,
-  Visibility as ViewerIcon,
-  QueueMusic as QueueMusicIcon,
-  RocketLaunch as FlowIcon,
-} from '@mui/icons-material';
-
-const DRAWER_WIDTH = 280;
-
-const COMMAND_ICONS = {
-  'analyze-v2': AnalyticsIcon,
-  'analyze-postprocess-ui': SpeedIcon,
-  'analyze': AnalyticsIcon,
-  'record': MovieIcon,
-  'postprocess-ui': PlayIcon,
-  'postprocess-sound': MusicIcon,
-  'apply-music': QueueMusicIcon,
-  'merge': MergeIcon,
-  'top': AnalyticsIcon,
-  'compress': CompressIcon,
-  'players': PeopleIcon,
-  'player-kills': PersonIcon,
-  'timestamps': ScheduleIcon,
-  'resync-music': SyncIcon,
-  'merge-music': MusicIcon,
-};
+import { Box } from '@mui/material';
+import AppBackdrop from './shell/AppBackdrop';
+import TitleBar from './shell/TitleBar';
+import Sidebar from './shell/Sidebar';
+import { useCommandContext } from '../context/CommandContext';
 
 function Layout({ children }) {
-  const navigate = useNavigate();
-  const location = useLocation();
   const [commands, setCommands] = useState([]);
   const [flows, setFlows] = useState([]);
-  const [flowsOpen, setFlowsOpen] = useState(true);
-  const [pipelineOpen, setPipelineOpen] = useState(true);
-  const [utilityOpen, setUtilityOpen] = useState(true);
+  const { runningCommand } = useCommandContext();
 
   useEffect(() => {
     if (window.electronAPI) {
@@ -73,217 +17,32 @@ function Layout({ children }) {
     }
   }, []);
 
-  const pipelineCommands = commands.filter(c => c.category === 'Pipeline');
-  const utilityCommands = commands.filter(c => c.category === 'Utility');
-
-  const isActive = (path) => location.pathname === path;
-  const isCommandActive = (commandId) => location.pathname === `/command/${commandId}`;
-  const isFlowActive = (flowId) => location.pathname === `/flow/${flowId}`;
-
-  const CommandIcon = ({ commandId }) => {
-    const Icon = COMMAND_ICONS[commandId] || BuildIcon;
-    return <Icon />;
-  };
+  const runningLabel = runningCommand
+    ? commands.find((c) => c.id === runningCommand)?.name || runningCommand
+    : null;
 
   return (
-    <Box sx={{ display: 'flex', height: '100vh' }}>
-      {/* Sidebar */}
-      <Drawer
-        variant="permanent"
-        sx={{
-          width: DRAWER_WIDTH,
-          flexShrink: 0,
-          '& .MuiDrawer-paper': {
-            width: DRAWER_WIDTH,
-            boxSizing: 'border-box',
-            bgcolor: 'background.paper',
-            borderRight: '1px solid',
-            borderColor: 'divider',
-          },
-        }}
-      >
-        {/* Logo / Title */}
-        <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
-          <Typography variant="h6" fontWeight="bold" color="primary">
-            CS:GO Highlights
-          </Typography>
-          <Typography variant="caption" color="text.secondary">
-            Video Production Tool
-          </Typography>
-        </Box>
-
-        <List sx={{ flex: 1, overflow: 'auto' }}>
-          {/* Home */}
-          <ListItem disablePadding>
-            <ListItemButton
-              selected={isActive('/')}
-              onClick={() => navigate('/')}
-            >
-              <ListItemIcon>
-                <HomeIcon />
-              </ListItemIcon>
-              <ListItemText primary="Home" />
-            </ListItemButton>
-          </ListItem>
-
-          {/* Highlights Viewer */}
-          <ListItem disablePadding>
-            <ListItemButton
-              selected={isActive('/viewer')}
-              onClick={() => navigate('/viewer')}
-            >
-              <ListItemIcon>
-                <ViewerIcon />
-              </ListItemIcon>
-              <ListItemText primary="Highlights Viewer" />
-            </ListItemButton>
-          </ListItem>
-
-          {/* Music Editor */}
-          <ListItem disablePadding>
-            <ListItemButton
-              selected={isActive('/music-editor')}
-              onClick={() => navigate('/music-editor')}
-            >
-              <ListItemIcon>
-                <QueueMusicIcon />
-              </ListItemIcon>
-              <ListItemText primary="Music Editor" />
-            </ListItemButton>
-          </ListItem>
-
-          <Divider sx={{ my: 1 }} />
-
-          {/* Flows */}
-          <ListItem disablePadding>
-            <ListItemButton onClick={() => setFlowsOpen(!flowsOpen)}>
-              <ListItemIcon>
-                <FlowIcon />
-              </ListItemIcon>
-              <ListItemText primary="Flows" />
-              {flowsOpen ? <ExpandLess /> : <ExpandMore />}
-            </ListItemButton>
-          </ListItem>
-          <Collapse in={flowsOpen} timeout="auto" unmountOnExit>
-            <List component="div" disablePadding>
-              {flows.map((flow) => (
-                <ListItem key={flow.id} disablePadding>
-                  <ListItemButton
-                    sx={{ pl: 4 }}
-                    selected={isFlowActive(flow.id)}
-                    onClick={() => navigate(`/flow/${flow.id}`)}
-                  >
-                    <ListItemIcon>
-                      <FlowIcon />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={flow.name}
-                      primaryTypographyProps={{ fontSize: '0.9rem' }}
-                    />
-                  </ListItemButton>
-                </ListItem>
-              ))}
-            </List>
-          </Collapse>
-
-          {/* Pipeline Commands */}
-          <ListItem disablePadding>
-            <ListItemButton onClick={() => setPipelineOpen(!pipelineOpen)}>
-              <ListItemIcon>
-                <PlayIcon />
-              </ListItemIcon>
-              <ListItemText primary="Pipeline" />
-              {pipelineOpen ? <ExpandLess /> : <ExpandMore />}
-            </ListItemButton>
-          </ListItem>
-          <Collapse in={pipelineOpen} timeout="auto" unmountOnExit>
-            <List component="div" disablePadding>
-              {pipelineCommands.map((cmd) => (
-                <ListItem key={cmd.id} disablePadding>
-                  <ListItemButton
-                    sx={{ pl: 4 }}
-                    selected={isCommandActive(cmd.id)}
-                    onClick={() => navigate(`/command/${cmd.id}`)}
-                  >
-                    <ListItemIcon>
-                      <CommandIcon commandId={cmd.id} />
-                    </ListItemIcon>
-                    <ListItemText 
-                      primary={cmd.name} 
-                      primaryTypographyProps={{ fontSize: '0.9rem' }}
-                    />
-                  </ListItemButton>
-                </ListItem>
-              ))}
-            </List>
-          </Collapse>
-
-          {/* Utility Commands */}
-          <ListItem disablePadding>
-            <ListItemButton onClick={() => setUtilityOpen(!utilityOpen)}>
-              <ListItemIcon>
-                <BuildIcon />
-              </ListItemIcon>
-              <ListItemText primary="Utility" />
-              {utilityOpen ? <ExpandLess /> : <ExpandMore />}
-            </ListItemButton>
-          </ListItem>
-          <Collapse in={utilityOpen} timeout="auto" unmountOnExit>
-            <List component="div" disablePadding>
-              {utilityCommands.map((cmd) => (
-                <ListItem key={cmd.id} disablePadding>
-                  <ListItemButton
-                    sx={{ pl: 4 }}
-                    selected={isCommandActive(cmd.id)}
-                    onClick={() => navigate(`/command/${cmd.id}`)}
-                  >
-                    <ListItemIcon>
-                      <CommandIcon commandId={cmd.id} />
-                    </ListItemIcon>
-                    <ListItemText 
-                      primary={cmd.name}
-                      primaryTypographyProps={{ fontSize: '0.9rem' }}
-                    />
-                  </ListItemButton>
-                </ListItem>
-              ))}
-            </List>
-          </Collapse>
-
-          <Divider sx={{ my: 1 }} />
-
-          {/* Settings */}
-          <ListItem disablePadding>
-            <ListItemButton
-              selected={isActive('/config')}
-              onClick={() => navigate('/config')}
-            >
-              <ListItemIcon>
-                <SettingsIcon />
-              </ListItemIcon>
-              <ListItemText primary="Global Config" />
-            </ListItemButton>
-          </ListItem>
-        </List>
-      </Drawer>
-
-      {/* Main content */}
+    <>
+      <AppBackdrop />
       <Box
-        component="main"
         sx={{
-          flexGrow: 1,
-          bgcolor: 'background.default',
-          height: '100vh',
-          overflow: 'hidden',
+          position: 'relative',
+          zIndex: 1,
           display: 'flex',
           flexDirection: 'column',
+          height: '100vh',
         }}
       >
-        <Box sx={{ flex: 1, overflow: 'auto' }}>
-          {children}
+        <TitleBar runningLabel={runningLabel} />
+
+        <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
+          <Sidebar commands={commands} flows={flows} />
+          <Box component="main" sx={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
+            {children}
+          </Box>
         </Box>
       </Box>
-    </Box>
+    </>
   );
 }
 

--- a/ui/src/components/PreviewPlayer.jsx
+++ b/ui/src/components/PreviewPlayer.jsx
@@ -10,6 +10,8 @@ import {
   formatPreviewTime,
 } from '../lib/musicEditor/timeline';
 import { pathToMediaUrl } from '../lib/musicEditor/media';
+import { tokens } from '../theme/tokens';
+import { MONO_STACK } from '../theme';
 
 const VIDEO_STYLE = 'width:100%;height:100%;object-fit:contain;position:absolute;top:0;left:0;display:none;';
 
@@ -250,7 +252,15 @@ const PreviewPlayer = forwardRef(function PreviewPlayer({
     <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
       <Box
         ref={containerRef}
-        sx={{ position: 'relative', flex: 1, bgcolor: '#000', borderRadius: 1, overflow: 'hidden', minHeight: 0 }}
+        sx={{
+          position: 'relative',
+          flex: 1,
+          bgcolor: '#000',
+          borderRadius: `${tokens.radius.md}px`,
+          border: `1px solid ${tokens.hairline}`,
+          overflow: 'hidden',
+          minHeight: 0,
+        }}
       >
         <Box
           ref={noClipRef}
@@ -268,8 +278,14 @@ const PreviewPlayer = forwardRef(function PreviewPlayer({
           sx={{
             display: 'none',
             position: 'absolute', bottom: 8, left: 8, right: 8,
-            bgcolor: 'rgba(0,0,0,0.7)', borderRadius: 1, px: 1, py: 0.5,
-            color: '#fff', fontSize: 12, zIndex: 2,
+            background: 'rgba(20, 23, 26, 0.70)',
+            backdropFilter: tokens.blur.panel,
+            WebkitBackdropFilter: tokens.blur.panel,
+            border: `1px solid ${tokens.hairline}`,
+            borderRadius: `${tokens.radius.sm}px`,
+            px: 1.25, py: 0.625,
+            color: tokens.text.primary, fontSize: 12, zIndex: 2,
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
           }}
         />
       </Box>
@@ -277,7 +293,11 @@ const PreviewPlayer = forwardRef(function PreviewPlayer({
       <audio ref={audioRef} style={{ display: 'none' }} />
 
       <Stack direction="row" spacing={2} alignItems="center" sx={{ mt: 1, flexShrink: 0 }}>
-        <Typography ref={timeDisplayRef} variant="body2" sx={{ minWidth: 80 }}>
+        <Typography
+          ref={timeDisplayRef}
+          variant="body2"
+          sx={{ minWidth: 86, fontFamily: MONO_STACK, fontVariantNumeric: 'tabular-nums' }}
+        >
           {formatPreviewTime(initialTime)}
         </Typography>
 

--- a/ui/src/components/Timeline.jsx
+++ b/ui/src/components/Timeline.jsx
@@ -8,15 +8,21 @@ import {
   getTimelineClickTime,
   getTimelineDuration,
 } from '../lib/musicEditor/timeline';
+import { tokens } from '../theme/tokens';
+import { sunkenSurface } from '../theme/glass';
 
+// Clips stay in a cool, muted family so a long timeline reads as one surface;
+// music takes the amber accent so the two tracks are told apart by hue.
 const CLIP_COLORS = [
-  '#2196F3', '#4CAF50', '#FF9800', '#E91E63', '#9C27B0',
-  '#00BCD4', '#FFEB3B', '#795548', '#607D8B', '#F44336',
+  '#5E98D9', '#4E8F86', '#7A8C99', '#6B7FA8', '#8C9B5E',
+  '#5D7EA0', '#9A8B6E', '#6E8C7A', '#84909B', '#5F8AA0',
 ];
 
 const MUSIC_COLORS = [
-  '#7C4DFF', '#651FFF', '#536DFE', '#448AFF', '#40C4FF',
+  '#DE9B35', '#C4832B', '#B96F2C', '#D0A73F', '#A9702A',
 ];
+
+const CLIP_RADIUS = 6;
 
 const Timeline = forwardRef(function Timeline({
   clips,
@@ -126,11 +132,10 @@ const Timeline = forwardRef(function Timeline({
     <Box
       ref={containerRef}
       sx={{
+        ...sunkenSurface({ radius: tokens.radius.md }),
         flex: 1,
         overflow: 'auto',
         position: 'relative',
-        bgcolor: '#1a1a2e',
-        borderRadius: 1,
         cursor: draggingClip !== null ? 'grabbing' : 'default',
       }}
     >
@@ -143,18 +148,18 @@ const Timeline = forwardRef(function Timeline({
         onClick={handleTimelineClick}
       >
         {/* Time markers */}
-        <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, height: 24, borderBottom: '1px solid #333', display: 'flex' }}>
+        <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, height: 24, borderBottom: `1px solid ${tokens.hairline}`, display: 'flex' }}>
           {timeMarkers.map((time) => (
             <Box key={time} sx={{ position: 'absolute', left: time * zoom, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-              <Typography variant="caption" sx={{ color: '#888', fontSize: 10 }}>{formatTimelineTime(time)}</Typography>
-              <Box sx={{ width: 1, height: 8, bgcolor: '#444' }} />
+              <Typography variant="caption" sx={{ color: tokens.text.secondary, fontSize: 10 }}>{formatTimelineTime(time)}</Typography>
+              <Box sx={{ width: 1, height: 8, bgcolor: tokens.hairlineStrong }} />
             </Box>
           ))}
         </Box>
 
         {/* Clips track */}
-        <Box sx={{ position: 'absolute', top: 30, left: 0, right: 0, height: 60, borderBottom: '1px solid #333' }}>
-          <Typography variant="caption" sx={{ position: 'absolute', left: -60, top: '50%', transform: 'translateY(-50%) rotate(-90deg)', color: '#666', whiteSpace: 'nowrap' }}>
+        <Box sx={{ position: 'absolute', top: 30, left: 0, right: 0, height: 60, borderBottom: `1px solid ${tokens.hairline}` }}>
+          <Typography variant="caption" sx={{ position: 'absolute', left: -60, top: '50%', transform: 'translateY(-50%) rotate(-90deg)', color: tokens.text.disabled, whiteSpace: 'nowrap' }}>
             Clips
           </Typography>
           {clips.map((clip, index) => {
@@ -172,10 +177,14 @@ const Timeline = forwardRef(function Timeline({
                     height: 50,
                     top: 5,
                     bgcolor: clipColor,
-                    borderRadius: 1,
+                    borderRadius: `${CLIP_RADIUS}px`,
                     cursor: isDragging ? 'grabbing' : 'grab',
-                    border: isSelected ? '2px solid #fff' : '1px solid rgba(255,255,255,0.3)',
-                    boxShadow: isSelected ? '0 0 10px rgba(255,255,255,0.5)' : 'none',
+                    border: isSelected
+                      ? `1px solid ${tokens.text.primary}`
+                      : `1px solid ${tokens.hairlineStrong}`,
+                    boxShadow: isSelected
+                      ? `0 0 0 2px ${tokens.accentSoft}, 0 4px 14px rgba(0,0,0,0.4)`
+                      : 'inset 0 1px 0 rgba(255,255,255,0.14)',
                     opacity: isDragging ? 0.8 : 1,
                     transition: isDragging ? 'none' : 'box-shadow 0.2s',
                     display: 'flex',
@@ -195,8 +204,8 @@ const Timeline = forwardRef(function Timeline({
         </Box>
 
         {/* Music track */}
-        <Box sx={{ position: 'absolute', top: 100, left: 0, right: 0, height: 60, borderBottom: '1px solid #333' }}>
-          <Typography variant="caption" sx={{ position: 'absolute', left: -60, top: '50%', transform: 'translateY(-50%) rotate(-90deg)', color: '#666', whiteSpace: 'nowrap' }}>
+        <Box sx={{ position: 'absolute', top: 100, left: 0, right: 0, height: 60, borderBottom: `1px solid ${tokens.hairline}` }}>
+          <Typography variant="caption" sx={{ position: 'absolute', left: -60, top: '50%', transform: 'translateY(-50%) rotate(-90deg)', color: tokens.text.disabled, whiteSpace: 'nowrap' }}>
             Music
           </Typography>
           {musicSegments.map(({ track, index, start, duration }) => (
@@ -209,8 +218,9 @@ const Timeline = forwardRef(function Timeline({
                   height: 50,
                   top: 5,
                   bgcolor: MUSIC_COLORS[index % MUSIC_COLORS.length],
-                  borderRadius: 1,
-                  border: '1px solid rgba(255,255,255,0.3)',
+                  borderRadius: `${CLIP_RADIUS}px`,
+                  border: `1px solid ${tokens.hairlineStrong}`,
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.14)',
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
@@ -233,7 +243,7 @@ const Timeline = forwardRef(function Timeline({
             top: 0,
             bottom: 0,
             width: 2,
-            bgcolor: '#ff4444',
+            bgcolor: tokens.status.error,
             pointerEvents: 'none',
             zIndex: 10,
             '&::before': {
@@ -245,7 +255,7 @@ const Timeline = forwardRef(function Timeline({
               height: 0,
               borderLeft: '7px solid transparent',
               borderRight: '7px solid transparent',
-              borderTop: '10px solid #ff4444',
+              borderTop: `10px solid ${tokens.status.error}`,
             },
           }}
         />

--- a/ui/src/components/commands/CommandFieldsPanel.jsx
+++ b/ui/src/components/commands/CommandFieldsPanel.jsx
@@ -12,10 +12,19 @@ function CommandFieldsPanel({
 }) {
   return (
     <Paper sx={{ p: 3, mb: 3 }}>
-      <Typography variant="h6" gutterBottom>
+      <Typography
+        sx={{
+          fontSize: '0.6875rem',
+          fontWeight: 700,
+          letterSpacing: '0.09em',
+          textTransform: 'uppercase',
+          color: 'text.disabled',
+          mb: 2.5,
+        }}
+      >
         {title}
       </Typography>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
         {fields.map((field) => (
           <CommandField
             key={field.name}

--- a/ui/src/components/commands/ExecutionOutput.jsx
+++ b/ui/src/components/commands/ExecutionOutput.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { Alert, Box, Paper } from '@mui/material';
+import { Alert, Box } from '@mui/material';
+import { tokens } from '../../theme/tokens';
+import { sunkenSurface } from '../../theme/glass';
+import { MONO_STACK } from '../../theme';
 
 function getLogColor(type) {
-  if (type === 'step-header') return '#64b5f6';
-  if (type === 'stderr') return '#ff6b6b';
-  return '#e0e0e0';
+  if (type === 'step-header') return tokens.accent;
+  if (type === 'stderr') return tokens.status.error;
+  return '#C3C9CE';
 }
 
 function defaultFormatResult(result) {
@@ -30,15 +33,16 @@ function ExecutionOutput({
       )}
 
       {logs.length > 0 && (
-        <Paper
+        <Box
           sx={{
+            ...sunkenSurface({ deep: true }),
             flex: 1,
-            minHeight: 200,
+            minHeight: 220,
             overflow: 'auto',
-            bgcolor: '#0d0d0d',
             p: 2,
-            fontFamily: 'monospace',
-            fontSize: '0.85rem',
+            fontFamily: MONO_STACK,
+            fontSize: '0.8125rem',
+            lineHeight: 1.55,
           }}
         >
           {logs.map((log, i) => (
@@ -47,17 +51,19 @@ function ExecutionOutput({
               component="pre"
               sx={{
                 m: 0,
+                fontFamily: 'inherit',
+                fontSize: 'inherit',
                 color: getLogColor(log.type),
                 whiteSpace: 'pre-wrap',
                 wordBreak: 'break-all',
-                fontWeight: log.type === 'step-header' ? 'bold' : 'normal',
+                fontWeight: log.type === 'step-header' ? 600 : 400,
               }}
             >
               {log.text}
             </Box>
           ))}
           <div ref={logsEndRef} />
-        </Paper>
+        </Box>
       )}
     </>
   );

--- a/ui/src/components/shell/AppBackdrop.jsx
+++ b/ui/src/components/shell/AppBackdrop.jsx
@@ -1,0 +1,29 @@
+import { Box } from '@mui/material';
+import { tokens } from '../../theme/tokens';
+
+/**
+ * The painted "wallpaper" every glass surface blurs against.
+ *
+ * Fixed and static — no animation, so it never costs a repaint during
+ * playback or log streaming.
+ */
+function AppBackdrop() {
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 0,
+        pointerEvents: 'none',
+        backgroundColor: tokens.backdrop.base,
+        backgroundImage: [
+          ...tokens.backdrop.washes,
+          `linear-gradient(160deg, ${tokens.backdrop.base} 0%, ${tokens.backdrop.end} 100%)`,
+        ].join(', '),
+      }}
+    />
+  );
+}
+
+export default AppBackdrop;

--- a/ui/src/components/shell/PageHeader.jsx
+++ b/ui/src/components/shell/PageHeader.jsx
@@ -1,0 +1,23 @@
+import { Box, Typography } from '@mui/material';
+
+/** Shared page title block: title + optional chip, subtitle and right-side actions. */
+function PageHeader({ title, subtitle, chip, actions, sx }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 3, ...sx }}>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <Typography variant="h4">{title}</Typography>
+          {chip}
+        </Box>
+        {subtitle && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
+            {subtitle}
+          </Typography>
+        )}
+      </Box>
+      {actions && <Box sx={{ display: 'flex', gap: 1.5, flexShrink: 0 }}>{actions}</Box>}
+    </Box>
+  );
+}
+
+export default PageHeader;

--- a/ui/src/components/shell/Sidebar.jsx
+++ b/ui/src/components/shell/Sidebar.jsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Box, ButtonBase, Collapse, Typography } from '@mui/material';
+import {
+  Home as HomeIcon,
+  Settings as SettingsIcon,
+  ExpandMore,
+  PlayArrow as PlayIcon,
+  Build as BuildIcon,
+  Movie as MovieIcon,
+  MusicNote as MusicIcon,
+  Merge as MergeIcon,
+  Analytics as AnalyticsIcon,
+  Speed as SpeedIcon,
+  Compress as CompressIcon,
+  Person as PersonIcon,
+  People as PeopleIcon,
+  Schedule as ScheduleIcon,
+  Sync as SyncIcon,
+  Visibility as ViewerIcon,
+  QueueMusic as QueueMusicIcon,
+  RocketLaunch as FlowIcon,
+} from '@mui/icons-material';
+import { tokens, transition } from '../../theme/tokens';
+
+const COMMAND_ICONS = {
+  'analyze-v2': AnalyticsIcon,
+  'analyze-postprocess-ui': SpeedIcon,
+  'analyze': AnalyticsIcon,
+  'record': MovieIcon,
+  'postprocess-ui': PlayIcon,
+  'postprocess-sound': MusicIcon,
+  'apply-music': QueueMusicIcon,
+  'merge': MergeIcon,
+  'top': AnalyticsIcon,
+  'compress': CompressIcon,
+  'players': PeopleIcon,
+  'player-kills': PersonIcon,
+  'timestamps': ScheduleIcon,
+  'resync-music': SyncIcon,
+  'merge-music': MusicIcon,
+};
+
+function NavItem({ icon: Icon, label, active, onClick, dense = false }) {
+  return (
+    <ButtonBase
+      onClick={onClick}
+      sx={{
+        width: '100%',
+        justifyContent: 'flex-start',
+        textAlign: 'left',
+        gap: 1.25,
+        px: 1.25,
+        py: dense ? 0.625 : 0.875,
+        borderRadius: `${tokens.radius.sm}px`,
+        color: active ? tokens.accent : tokens.text.secondary,
+        background: active ? tokens.accentSoft : 'transparent',
+        transition: transition(),
+        '&:hover': {
+          background: active ? tokens.accentSoft : tokens.surface.glassLo,
+          color: active ? tokens.accent : tokens.text.primary,
+        },
+      }}
+    >
+      <Icon sx={{ fontSize: dense ? 17 : 19, flexShrink: 0 }} />
+      <Typography
+        noWrap
+        sx={{
+          minWidth: 0,
+          fontSize: dense ? '0.8125rem' : '0.875rem',
+          fontWeight: active ? 600 : 450,
+          letterSpacing: '-0.005em',
+        }}
+      >
+        {label}
+      </Typography>
+    </ButtonBase>
+  );
+}
+
+function SectionHeader({ label, open, onToggle }) {
+  return (
+    <ButtonBase
+      onClick={onToggle}
+      sx={{
+        width: '100%',
+        justifyContent: 'space-between',
+        px: 1.25,
+        py: 0.75,
+        mt: 1.75,
+        mb: 0.25,
+        borderRadius: `${tokens.radius.sm - 2}px`,
+        '&:hover': { background: tokens.surface.glassLo },
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.6875rem',
+          fontWeight: 700,
+          letterSpacing: '0.09em',
+          textTransform: 'uppercase',
+          color: tokens.text.disabled,
+        }}
+      >
+        {label}
+      </Typography>
+      <ExpandMore
+        sx={{
+          fontSize: 15,
+          color: tokens.text.disabled,
+          transform: open ? 'none' : 'rotate(-90deg)',
+          transition: transition(['transform']),
+        }}
+      />
+    </ButtonBase>
+  );
+}
+
+function Sidebar({ commands, flows }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [flowsOpen, setFlowsOpen] = useState(true);
+  const [pipelineOpen, setPipelineOpen] = useState(true);
+  const [utilityOpen, setUtilityOpen] = useState(true);
+
+  const pipelineCommands = commands.filter((c) => c.category === 'Pipeline');
+  const utilityCommands = commands.filter((c) => c.category === 'Utility');
+
+  const isActive = (path) => location.pathname === path;
+
+  const commandItems = (list) =>
+    list.map((cmd) => (
+      <NavItem
+        key={cmd.id}
+        dense
+        icon={COMMAND_ICONS[cmd.id] || BuildIcon}
+        label={cmd.name}
+        active={location.pathname === `/command/${cmd.id}`}
+        onClick={() => navigate(`/command/${cmd.id}`)}
+      />
+    ));
+
+  return (
+    <Box
+      component="nav"
+      sx={{
+        position: 'relative',
+        zIndex: 2,
+        width: tokens.sidebarWidth,
+        flexShrink: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        background: tokens.surface.glass,
+        backdropFilter: tokens.blur.panel,
+        WebkitBackdropFilter: tokens.blur.panel,
+        borderRight: `1px solid ${tokens.hairline}`,
+      }}
+    >
+      <Box sx={{ flex: 1, overflowY: 'auto', px: 1.25, py: 1.25, display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+        <NavItem icon={HomeIcon} label="Home" active={isActive('/')} onClick={() => navigate('/')} />
+        <NavItem
+          icon={ViewerIcon}
+          label="Highlights Viewer"
+          active={isActive('/viewer')}
+          onClick={() => navigate('/viewer')}
+        />
+        <NavItem
+          icon={QueueMusicIcon}
+          label="Music Editor"
+          active={isActive('/music-editor')}
+          onClick={() => navigate('/music-editor')}
+        />
+
+        <SectionHeader label="Flows" open={flowsOpen} onToggle={() => setFlowsOpen(!flowsOpen)} />
+        <Collapse in={flowsOpen} timeout="auto" unmountOnExit>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+            {flows.map((flow) => (
+              <NavItem
+                key={flow.id}
+                dense
+                icon={FlowIcon}
+                label={flow.name}
+                active={location.pathname === `/flow/${flow.id}`}
+                onClick={() => navigate(`/flow/${flow.id}`)}
+              />
+            ))}
+          </Box>
+        </Collapse>
+
+        <SectionHeader label="Pipeline" open={pipelineOpen} onToggle={() => setPipelineOpen(!pipelineOpen)} />
+        <Collapse in={pipelineOpen} timeout="auto" unmountOnExit>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>{commandItems(pipelineCommands)}</Box>
+        </Collapse>
+
+        <SectionHeader label="Utility" open={utilityOpen} onToggle={() => setUtilityOpen(!utilityOpen)} />
+        <Collapse in={utilityOpen} timeout="auto" unmountOnExit>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>{commandItems(utilityCommands)}</Box>
+        </Collapse>
+      </Box>
+
+      <Box sx={{ px: 1.25, py: 1.25, borderTop: `1px solid ${tokens.hairline}` }}>
+        <NavItem
+          icon={SettingsIcon}
+          label="Global Config"
+          active={isActive('/config')}
+          onClick={() => navigate('/config')}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+export default Sidebar;

--- a/ui/src/components/shell/TitleBar.jsx
+++ b/ui/src/components/shell/TitleBar.jsx
@@ -1,0 +1,92 @@
+import { Box, Typography } from '@mui/material';
+import { keyframes } from '@emotion/react';
+import { tokens } from '../../theme/tokens';
+
+const pulse = keyframes`
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.78); }
+`;
+
+/**
+ * Draggable glass strip standing in for the native title bar.
+ *
+ * Windows still draws its own caption buttons on the right (titleBarOverlay),
+ * so the content is constrained to `titlebar-area-width` to stay clear of them.
+ */
+function TitleBar({ runningLabel }) {
+  return (
+    <Box
+      component="header"
+      sx={{
+        position: 'relative',
+        zIndex: 3,
+        flexShrink: 0,
+        height: tokens.titleBarHeight,
+        background: 'rgba(255, 255, 255, 0.04)',
+        backdropFilter: tokens.blur.bar,
+        WebkitBackdropFilter: tokens.blur.bar,
+        borderBottom: `1px solid ${tokens.hairline}`,
+        WebkitAppRegion: 'drag',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.25,
+          height: '100%',
+          width: 'env(titlebar-area-width, 100%)',
+          pl: 2,
+          pr: 1.5,
+        }}
+      >
+        <Box
+          sx={{
+            width: 18,
+            height: 18,
+            borderRadius: '4px',
+            flexShrink: 0,
+            background: `linear-gradient(140deg, ${tokens.accent}, #B4741F)`,
+            boxShadow: `0 0 12px ${tokens.accentSoft}`,
+          }}
+        />
+        <Typography
+          sx={{
+            fontSize: '0.8125rem',
+            fontWeight: 600,
+            letterSpacing: '-0.01em',
+            color: tokens.text.primary,
+          }}
+        >
+          CS:GO Highlights
+        </Typography>
+
+        <Box sx={{ flex: 1 }} />
+
+        {runningLabel && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+            <Box
+              sx={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                flexShrink: 0,
+                background: tokens.status.success,
+                boxShadow: `0 0 8px ${tokens.status.success}`,
+                animation: `${pulse} 1.6s ease-in-out infinite`,
+              }}
+            />
+            <Typography
+              noWrap
+              sx={{ fontSize: '0.75rem', color: tokens.text.secondary, minWidth: 0 }}
+            >
+              Running {runningLabel}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+export default TitleBar;

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -1,42 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+import { ThemeProvider, CssBaseline } from '@mui/material';
 import { HashRouter } from 'react-router-dom';
 import App from './App';
+import theme from './theme';
 import { CommandProvider } from './context/CommandContext';
 import { ViewerProvider } from './context/ViewerContext';
 
-const darkTheme = createTheme({
-  palette: {
-    mode: 'dark',
-    primary: {
-      main: '#90caf9',
-    },
-    secondary: {
-      main: '#f48fb1',
-    },
-    background: {
-      default: '#121212',
-      paper: '#1e1e1e',
-    },
-  },
-  typography: {
-    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
-  },
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          textTransform: 'none',
-        },
-      },
-    },
-  },
-});
-
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ThemeProvider theme={darkTheme}>
+    <ThemeProvider theme={theme}>
       <CssBaseline />
       <CommandProvider>
         <ViewerProvider>

--- a/ui/src/pages/CommandPage.jsx
+++ b/ui/src/pages/CommandPage.jsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/icons-material';
 import CommandFieldsPanel from '../components/commands/CommandFieldsPanel';
 import ExecutionOutput from '../components/commands/ExecutionOutput';
+import PageHeader from '../components/shell/PageHeader';
 import { useCommandContext } from '../context/CommandContext';
 import { useElectronApi } from '../hooks/commands/useElectronApi';
 
@@ -224,7 +225,7 @@ function CommandPage() {
   if (!command) {
     return (
       <Box sx={{ p: 4 }}>
-        <Typography>Loading...</Typography>
+        <Typography color="text.secondary">Loading…</Typography>
         {apiError && (
           <Alert severity="error" sx={{ mt: 2 }}>
             {apiError}
@@ -235,19 +236,12 @@ function CommandPage() {
   }
 
   return (
-    <Box sx={{ p: 4, minHeight: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <Typography variant="h4" fontWeight="bold">
-            {command.name}
-          </Typography>
-          <Chip label={command.category} size="small" color="primary" variant="outlined" />
-        </Box>
-        <Typography variant="body1" color="text.secondary" sx={{ mt: 1 }}>
-          {command.description}
-        </Typography>
-      </Box>
+    <Box sx={{ p: 4, minHeight: '100%', display: 'flex', flexDirection: 'column', maxWidth: 1200 }}>
+      <PageHeader
+        title={command.name}
+        subtitle={command.description}
+        chip={<Chip label={command.category} size="small" color="primary" variant="outlined" />}
+      />
 
       {showApiError && (
         <Alert severity="error" sx={{ mb: 2 }}>

--- a/ui/src/pages/FlowPage.jsx
+++ b/ui/src/pages/FlowPage.jsx
@@ -22,6 +22,7 @@ import {
 } from '@mui/icons-material';
 import CommandFieldsPanel from '../components/commands/CommandFieldsPanel';
 import ExecutionOutput from '../components/commands/ExecutionOutput';
+import PageHeader from '../components/shell/PageHeader';
 import { useElectronApi } from '../hooks/commands/useElectronApi';
 
 function formatFlowResult(result) {
@@ -198,7 +199,7 @@ function FlowPage() {
   if (!flow) {
     return (
       <Box sx={{ p: 4 }}>
-        <Typography>Loading...</Typography>
+        <Typography color="text.secondary">Loading…</Typography>
         {apiError && (
           <Alert severity="error" sx={{ mt: 2 }}>
             {apiError}
@@ -212,19 +213,12 @@ function FlowPage() {
   const progress = flow.steps.length > 0 ? (completedSteps / flow.steps.length) * 100 : 0;
 
   return (
-    <Box sx={{ p: 4, minHeight: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <Typography variant="h4" fontWeight="bold">
-            {flow.name}
-          </Typography>
-          <Chip label="Flow" size="small" color="secondary" variant="outlined" />
-        </Box>
-        <Typography variant="body1" color="text.secondary" sx={{ mt: 1 }}>
-          {flow.description}
-        </Typography>
-      </Box>
+    <Box sx={{ p: 4, minHeight: '100%', display: 'flex', flexDirection: 'column', maxWidth: 1200 }}>
+      <PageHeader
+        title={flow.name}
+        subtitle={flow.description}
+        chip={<Chip label="Flow" size="small" color="primary" variant="outlined" />}
+      />
 
       {showApiError && (
         <Alert severity="error" sx={{ mb: 2 }}>
@@ -269,7 +263,9 @@ function FlowPage() {
                 icon={getStepIcon(stepStatuses[i])}
                 sx={{
                   '& .MuiStepLabel-label': {
-                    fontWeight: stepStatuses[i] === 'running' ? 'bold' : 'normal',
+                    fontSize: '0.875rem',
+                    fontWeight: stepStatuses[i] === 'running' ? 600 : 450,
+                    ...(stepStatuses[i] === 'running' && { color: 'primary.main' }),
                   },
                 }}
               >

--- a/ui/src/pages/GlobalConfig.jsx
+++ b/ui/src/pages/GlobalConfig.jsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/icons-material';
 import ConfigSection from '../components/config/ConfigSection';
 import { CONFIG_SECTIONS } from '../components/config/configSections';
+import PageHeader from '../components/shell/PageHeader';
 
 function GlobalConfig() {
   const [config, setConfig] = useState(null);
@@ -108,7 +109,7 @@ function GlobalConfig() {
   if (loading) {
     return (
       <Box sx={{ p: 4 }}>
-        <Typography>Loading config...</Typography>
+        <Typography color="text.secondary">Loading config…</Typography>
       </Box>
     );
   }
@@ -135,49 +136,54 @@ function GlobalConfig() {
   }
 
   return (
-    <Box sx={{ p: 4 }}>
-      {/* Header */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Box>
-          <Typography variant="h4" fontWeight="bold">
-            Global Configuration
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Default values for all commands. These can be overridden per-command.
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          <Button
-            variant="outlined"
-            startIcon={<RefreshIcon />}
-            onClick={loadConfig}
-            disabled={loading || saving}
-          >
-            Reset
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={<SaveIcon />}
-            onClick={saveConfig}
-            disabled={saving || loading}
-          >
-            {saving ? 'Saving...' : 'Save'}
-          </Button>
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      {/* Header stays put while the sections scroll underneath. */}
+      <Box sx={{ flexShrink: 0, px: 4, pt: 4, pb: 2.5 }}>
+        <Box sx={{ maxWidth: 1400 }}>
+          <PageHeader
+            sx={{ mb: 0, alignItems: 'center' }}
+            title="Global Configuration"
+            subtitle="Default values for all commands. These can be overridden per-command."
+            actions={
+              <>
+                <Button
+                  variant="outlined"
+                  startIcon={<RefreshIcon />}
+                  onClick={loadConfig}
+                  disabled={loading || saving}
+                >
+                  Reset
+                </Button>
+                <Button
+                  variant="contained"
+                  startIcon={<SaveIcon />}
+                  onClick={saveConfig}
+                  disabled={saving || loading}
+                >
+                  {saving ? 'Saving…' : 'Save'}
+                </Button>
+              </>
+            }
+          />
         </Box>
       </Box>
 
-      {CONFIG_SECTIONS.map((section) => (
-        <ConfigSection
-          key={section.id}
-          section={section}
-          config={config}
-          expanded={expanded.includes(section.id)}
-          onAccordionChange={handleAccordion}
-          onFieldChange={handleChange}
-          onSelectFolder={handleSelectFolder}
-          onSelectFile={handleSelectFile}
-        />
-      ))}
+      <Box sx={{ flex: 1, overflowY: 'auto', px: 4, pb: 4 }}>
+        <Box sx={{ maxWidth: 1400 }}>
+          {CONFIG_SECTIONS.map((section) => (
+            <ConfigSection
+              key={section.id}
+              section={section}
+              config={config}
+              expanded={expanded.includes(section.id)}
+              onAccordionChange={handleAccordion}
+              onFieldChange={handleChange}
+              onSelectFolder={handleSelectFolder}
+              onSelectFile={handleSelectFile}
+            />
+          ))}
+        </Box>
+      </Box>
 
       {/* Snackbar */}
       <Snackbar

--- a/ui/src/pages/HighlightsViewer.jsx
+++ b/ui/src/pages/HighlightsViewer.jsx
@@ -29,6 +29,8 @@ import {
   ExpandLess as CollapseIcon,
   Refresh as RefreshIcon,
 } from '@mui/icons-material';
+import PageHeader from '../components/shell/PageHeader';
+import { sunkenSurface } from '../theme/glass';
 import { useViewerContext } from '../context/ViewerContext';
 import {
   filterHighlights,
@@ -48,7 +50,7 @@ import {
 
 const TYPE_COLORS = {
   'kill-series': 'primary',
-  'clutch': 'secondary',
+  'clutch': 'success',
   'collateral': 'warning',
   'knife': 'error',
   'one-tap': 'info',
@@ -160,18 +162,13 @@ function HighlightsViewer() {
 
   return (
     <Box sx={{ p: 4, height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Typography variant="h4" fontWeight="bold" gutterBottom>
-          Highlights Viewer
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          Browse and analyze detected highlights from highlights.json
-        </Typography>
-      </Box>
+      <PageHeader
+        title="Highlights Viewer"
+        subtitle="Browse and analyze detected highlights from highlights.json"
+      />
 
       {/* File Selection */}
-      <Paper sx={{ p: 2, mb: 3 }}>
+      <Paper sx={{ p: 2, mb: 2.5 }}>
         <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
           <TextField
             label="Highlights File"
@@ -207,9 +204,9 @@ function HighlightsViewer() {
 
       {/* Summary */}
       {data && (
-        <Paper sx={{ p: 2, mb: 3 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
-            <Typography variant="subtitle2">File Type:</Typography>
+        <Paper sx={{ p: 2.5, mb: 2.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>
+            <Typography variant="subtitle2">File Type</Typography>
             <Chip 
               label={fileType} 
               color={
@@ -249,9 +246,9 @@ function HighlightsViewer() {
 
       {/* Filters */}
       {data && (
-        <Paper sx={{ p: 2, mb: 3 }}>
+        <Paper sx={{ p: 2.5, mb: 2.5 }}>
           <Typography variant="subtitle2" gutterBottom>Filters</Typography>
-          <Box sx={{ display: 'flex', gap: 2 }}>
+          <Box sx={{ display: 'flex', gap: 2, mt: 1.5, flexWrap: 'wrap', alignItems: 'center' }}>
             <FormControl sx={{ minWidth: 150 }}>
               <InputLabel>Type</InputLabel>
               <Select
@@ -425,7 +422,7 @@ function HighlightsViewer() {
                   <TableRow>
                     <TableCell colSpan={12} sx={{ p: 0 }}>
                       <Collapse in={expandedRows[h.id]} timeout="auto" unmountOnExit>
-                        <Box sx={{ p: 2, bgcolor: 'background.default' }}>
+                        <Box sx={{ ...sunkenSurface({ radius: 0 }), border: 'none', p: 2.5 }}>
                           <Grid container spacing={2}>
                             <Grid item xs={12}>
                               <Typography variant="subtitle2" gutterBottom>
@@ -518,9 +515,12 @@ function HighlightsViewer() {
 
       {/* Empty State */}
       {!data && !loading && !error && (
-        <Paper sx={{ p: 4, textAlign: 'center' }}>
-          <Typography color="text.secondary">
-            Select a highlights.json file and click Load to view highlights
+        <Paper sx={{ p: 6, textAlign: 'center' }}>
+          <Typography variant="h6" gutterBottom>
+            No file loaded
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Select a highlights.json file and click Load to view highlights.
           </Typography>
         </Paper>
       )}

--- a/ui/src/pages/Home.jsx
+++ b/ui/src/pages/Home.jsx
@@ -8,8 +8,9 @@ import {
   CardActionArea,
   Grid,
   Chip,
-  Divider,
+  Paper,
 } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import {
   PlayArrow as PlayIcon,
   Build as BuildIcon,
@@ -18,6 +19,33 @@ import {
   Speed as SpeedIcon,
   RocketLaunch as FlowIcon,
 } from '@mui/icons-material';
+import PageHeader from '../components/shell/PageHeader';
+import { tokens, transition } from '../theme/tokens';
+
+const tileSx = {
+  height: '100%',
+  transition: transition(['transform', 'border-color', 'background-color']),
+  '&:hover': {
+    transform: 'translateY(-2px)',
+    borderColor: tokens.hairlineStrong,
+    background: tokens.surface.glassHi,
+  },
+};
+
+function Section({ icon: Icon, title, description, children }) {
+  return (
+    <Box sx={{ mb: 5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 0.5 }}>
+        <Icon sx={{ fontSize: 18, color: 'primary.main' }} />
+        <Typography variant="h5">{title}</Typography>
+      </Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {description}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
 
 function Home() {
   const navigate = useNavigate();
@@ -35,30 +63,21 @@ function Home() {
   const utilityCommands = commands.filter(c => c.category === 'Utility');
 
   const CommandCard = ({ command }) => (
-    <Card 
-      sx={{ 
-        height: '100%',
-        transition: 'transform 0.2s, box-shadow 0.2s',
-        '&:hover': {
-          transform: 'translateY(-4px)',
-          boxShadow: 4,
-        },
-      }}
-    >
-      <CardActionArea 
+    <Card sx={tileSx}>
+      <CardActionArea
         onClick={() => navigate(`/command/${command.id}`)}
-        sx={{ height: '100%', p: 1 }}
+        sx={{ height: '100%', borderRadius: `${tokens.radius.lg}px` }}
       >
-        <CardContent>
+        <CardContent sx={{ p: 2.5 }}>
           <Typography variant="h6" gutterBottom>
             {command.name}
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
             {command.description}
           </Typography>
-          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
             {command.options?.filter(o => o.required).map((opt) => (
-              <Chip 
+              <Chip
                 key={opt.name}
                 label={opt.label || opt.name}
                 size="small"
@@ -73,61 +92,38 @@ function Home() {
   );
 
   return (
-    <Box sx={{ p: 4 }}>
-      {/* Header */}
-      <Box sx={{ mb: 4 }}>
-        <Typography variant="h4" fontWeight="bold" gutterBottom>
-          CS:GO Highlights Tool
-        </Typography>
-        <Typography variant="body1" color="text.secondary">
-          Automatically detect and render impressive gameplay moments from demo files.
-        </Typography>
-      </Box>
+    <Box sx={{ p: 4, maxWidth: 1800 }}>
+      <PageHeader
+        title="CS:GO Highlights Tool"
+        subtitle="Automatically detect and render impressive gameplay moments from demo files."
+      />
 
-      {/* Flows */}
       {flows.length > 0 && (
-        <Box sx={{ mb: 4 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-            <FlowIcon color="secondary" />
-            <Typography variant="h5">Flows</Typography>
-          </Box>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Pre-configured pipelines that run multiple commands in sequence.
-          </Typography>
-
+        <Section
+          icon={FlowIcon}
+          title="Flows"
+          description="Pre-configured pipelines that run multiple commands in sequence."
+        >
           <Grid container spacing={2}>
             {flows.map((flow) => (
-              <Grid item xs={12} sm={6} md={4} key={flow.id}>
-                <Card
-                  sx={{
-                    height: '100%',
-                    transition: 'transform 0.2s, box-shadow 0.2s',
-                    '&:hover': {
-                      transform: 'translateY(-4px)',
-                      boxShadow: 4,
-                    },
-                    border: '1px solid',
-                    borderColor: 'secondary.main',
-                  }}
-                >
+              <Grid item xs={12} sm={6} md={4} xl={3} key={flow.id}>
+                <Card sx={{ ...tileSx, borderColor: alpha(tokens.accent, 0.3) }}>
                   <CardActionArea
                     onClick={() => navigate(`/flow/${flow.id}`)}
-                    sx={{ height: '100%', p: 1 }}
+                    sx={{ height: '100%', borderRadius: `${tokens.radius.lg}px` }}
                   >
-                    <CardContent>
+                    <CardContent sx={{ p: 2.5 }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                        <FlowIcon color="secondary" fontSize="small" />
-                        <Typography variant="h6">
-                          {flow.name}
-                        </Typography>
+                        <FlowIcon sx={{ fontSize: 17, color: 'primary.main' }} />
+                        <Typography variant="h6">{flow.name}</Typography>
                       </Box>
-                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
                         {flow.description}
                       </Typography>
                       <Chip
                         label={`${flow.steps?.length || 0} steps`}
                         size="small"
-                        color="secondary"
+                        color="primary"
                         variant="outlined"
                       />
                     </CardContent>
@@ -136,91 +132,76 @@ function Home() {
               </Grid>
             ))}
           </Grid>
-        </Box>
+        </Section>
       )}
 
-      <Divider sx={{ my: 4 }} />
-
-      {/* Quick Start Pipeline */}
-      <Box sx={{ mb: 4 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-          <PlayIcon color="primary" />
-          <Typography variant="h5">Pipeline</Typography>
-        </Box>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Run these commands in order to go from demo files to final highlight video.
-        </Typography>
-        
+      <Section
+        icon={PlayIcon}
+        title="Pipeline"
+        description="Run these commands in order to go from demo files to final highlight video."
+      >
         <Grid container spacing={2}>
           {pipelineCommands.map((cmd) => (
-            <Grid item xs={12} sm={6} md={4} key={cmd.id}>
+            <Grid item xs={12} sm={6} md={4} xl={3} key={cmd.id}>
               <CommandCard command={cmd} />
             </Grid>
           ))}
         </Grid>
-      </Box>
+      </Section>
 
-      <Divider sx={{ my: 4 }} />
-
-      {/* Utility Commands */}
-      <Box>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-          <BuildIcon color="secondary" />
-          <Typography variant="h5">Utility</Typography>
-        </Box>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Additional tools for specific tasks.
-        </Typography>
-        
+      <Section
+        icon={BuildIcon}
+        title="Utility"
+        description="Additional tools for specific tasks."
+      >
         <Grid container spacing={2}>
           {utilityCommands.map((cmd) => (
-            <Grid item xs={12} sm={6} md={4} key={cmd.id}>
+            <Grid item xs={12} sm={6} md={4} xl={3} key={cmd.id}>
               <CommandCard command={cmd} />
             </Grid>
           ))}
         </Grid>
-      </Box>
+      </Section>
 
-      {/* V2 Pipeline Guide */}
-      <Box sx={{ mt: 4, p: 3, bgcolor: 'background.paper', borderRadius: 2 }}>
+      <Paper sx={{ p: 3 }}>
         <Typography variant="h6" gutterBottom>
           Recommended V2 Pipeline
         </Typography>
-        <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
-          <Chip 
-            icon={<AnalyticsIcon />} 
-            label="1. Analyze V2" 
+        <Box sx={{ display: 'flex', gap: 1.25, alignItems: 'center', flexWrap: 'wrap', mt: 2 }}>
+          <Chip
+            icon={<AnalyticsIcon />}
+            label="1. Analyze V2"
             onClick={() => navigate('/command/analyze-v2')}
             clickable
           />
-          <Typography color="text.secondary">→</Typography>
-          <Chip 
-            icon={<SpeedIcon />} 
-            label="2. Analyze Postprocess UI" 
+          <Typography color="text.disabled">→</Typography>
+          <Chip
+            icon={<SpeedIcon />}
+            label="2. Analyze Postprocess UI"
             onClick={() => navigate('/command/analyze-postprocess-ui')}
             clickable
           />
-          <Typography color="text.secondary">→</Typography>
-          <Chip 
-            icon={<MovieIcon />} 
-            label="3. Record" 
+          <Typography color="text.disabled">→</Typography>
+          <Chip
+            icon={<MovieIcon />}
+            label="3. Record"
             onClick={() => navigate('/command/record')}
             clickable
           />
-          <Typography color="text.secondary">→</Typography>
-          <Chip 
-            label="4. Postprocess UI" 
+          <Typography color="text.disabled">→</Typography>
+          <Chip
+            label="4. Postprocess UI"
             onClick={() => navigate('/command/postprocess-ui')}
             clickable
           />
-          <Typography color="text.secondary">→</Typography>
-          <Chip 
-            label="5. Merge" 
+          <Typography color="text.disabled">→</Typography>
+          <Chip
+            label="5. Merge"
             onClick={() => navigate('/command/merge')}
             clickable
           />
         </Box>
-      </Box>
+      </Paper>
     </Box>
   );
 }

--- a/ui/src/pages/MusicEditor.jsx
+++ b/ui/src/pages/MusicEditor.jsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   CircularProgress,
   Alert,
+  Snackbar,
 } from '@mui/material';
 import {
   FolderOpen as FolderIcon,
@@ -33,6 +34,7 @@ import {
   initializeClips,
   moveClip,
 } from '../lib/musicEditor/timeline';
+import { MONO_STACK } from '../theme';
 
 export default function MusicEditor() {
   // Data state (causes re-render only when data changes)
@@ -45,6 +47,7 @@ export default function MusicEditor() {
   const [zoom, setZoom] = useState(50);
   const [selectedClipIndex, setSelectedClipIndex] = useState(null);
   const [previewHeight, setPreviewHeight] = useState(380);
+  const [savedPath, setSavedPath] = useState(null);
 
   // Time as ref - NO state, NO re-renders during playback
   const timeRef = useRef(0);
@@ -167,7 +170,7 @@ export default function MusicEditor() {
         createdAt: new Date().toISOString(),
       });
       await window.electronAPI.saveMusicTimeline(outputPath, data);
-      alert(`Saved to: ${outputPath}`);
+      setSavedPath(outputPath);
     } catch (e) {
       setError(e.message);
     }
@@ -253,7 +256,11 @@ export default function MusicEditor() {
                 <IconButton onClick={togglePlayPause} color="primary" size="large">
                   {isPlaying ? <PauseIcon /> : <PlayIcon />}
                 </IconButton>
-                <Typography ref={timeDisplayRef} variant="h5" sx={{ fontFamily: 'monospace' }}>
+                <Typography
+                  ref={timeDisplayRef}
+                  variant="h5"
+                  sx={{ fontFamily: MONO_STACK, fontVariantNumeric: 'tabular-nums' }}
+                >
                   {formatEditorTime(timeRef.current)}
                 </Typography>
               </Stack>
@@ -304,7 +311,13 @@ export default function MusicEditor() {
               <Tooltip title="Zoom Out">
                 <IconButton onClick={handleZoomOut} size="small"><ZoomOutIcon /></IconButton>
               </Tooltip>
-              <Typography variant="body2">{zoom.toFixed(0)} px/s</Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ fontFamily: MONO_STACK, fontVariantNumeric: 'tabular-nums', minWidth: 62, textAlign: 'center' }}
+              >
+                {zoom.toFixed(0)} px/s
+              </Typography>
               <Tooltip title="Zoom In">
                 <IconButton onClick={handleZoomIn} size="small"><ZoomInIcon /></IconButton>
               </Tooltip>
@@ -326,11 +339,23 @@ export default function MusicEditor() {
       )}
 
       {!loading && clips.length === 0 && (
-        <Paper sx={{ p: 4, textAlign: 'center' }}>
-          <Typography variant="h6" color="text.secondary" gutterBottom>No clips loaded</Typography>
-          <Typography color="text.secondary">Select a folder with video clips to get started, or load an existing timeline.</Typography>
+        <Paper sx={{ p: 6, textAlign: 'center' }}>
+          <Typography variant="h6" gutterBottom>No clips loaded</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Select a folder with video clips to get started, or load an existing timeline.
+          </Typography>
         </Paper>
       )}
+
+      <Snackbar
+        open={Boolean(savedPath)}
+        autoHideDuration={4000}
+        onClose={() => setSavedPath(null)}
+      >
+        <Alert severity="success" onClose={() => setSavedPath(null)}>
+          Saved to {savedPath}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/ui/src/theme/glass.js
+++ b/ui/src/theme/glass.js
@@ -1,0 +1,40 @@
+import { tokens } from './tokens';
+
+/**
+ * Translucent panel — the standard elevated surface.
+ *
+ * The inset top highlight is what makes the top edge catch light; without it
+ * the panel reads as a flat translucent rectangle rather than glass.
+ */
+export function glassSurface({
+  radius = tokens.radius.lg,
+  blur = tokens.blur.panel,
+  background = tokens.surface.glass,
+  border = tokens.hairline,
+  shadow = '0 8px 32px rgba(0, 0, 0, 0.28)',
+} = {}) {
+  return {
+    background,
+    backgroundImage: 'none',
+    backdropFilter: blur,
+    WebkitBackdropFilter: blur,
+    border: border ? `1px solid ${border}` : 'none',
+    borderRadius: radius,
+    boxShadow: ['inset 0 1px 0 rgba(255, 255, 255, 0.08)', shadow].filter(Boolean).join(', '),
+  };
+}
+
+/**
+ * Recessed surface — log output, video frame, timeline tracks.
+ *
+ * No backdrop blur here: these sit *under* the glass, not on it.
+ */
+export function sunkenSurface({ radius = tokens.radius.md, deep = false } = {}) {
+  return {
+    background: deep ? tokens.surface.sunkenDeep : tokens.surface.sunken,
+    backgroundImage: 'none',
+    border: `1px solid ${tokens.hairline}`,
+    borderRadius: radius,
+    boxShadow: 'inset 0 1px 2px rgba(0, 0, 0, 0.40)',
+  };
+}

--- a/ui/src/theme/index.js
+++ b/ui/src/theme/index.js
@@ -1,0 +1,397 @@
+import { createTheme, alpha } from '@mui/material/styles';
+import { tokens, transition } from './tokens';
+import { glassSurface, sunkenSurface } from './glass';
+
+const FONT_STACK =
+  '-apple-system, "Segoe UI Variable Text", "Segoe UI", system-ui, "Helvetica Neue", Arial, sans-serif';
+const DISPLAY_STACK =
+  '-apple-system, "Segoe UI Variable Display", "Segoe UI", system-ui, "Helvetica Neue", Arial, sans-serif';
+export const MONO_STACK =
+  '"Cascadia Code", "SF Mono", ui-monospace, "JetBrains Mono", Consolas, monospace';
+
+/** Resolves an `ownerState.color` to a palette colour, or null for `default`/`inherit`. */
+function paletteColor(theme, color) {
+  if (!color || color === 'default' || color === 'inherit') return null;
+  return theme.palette[color]?.main ?? null;
+}
+
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: { main: tokens.accent, contrastText: '#14171A' },
+    // One accent: `color="secondary"` resolves to the same hue rather than a
+    // competing one. Distinction comes from icons and labels, not extra colour.
+    secondary: { main: tokens.accent, contrastText: '#14171A' },
+    success: { main: tokens.status.success, contrastText: '#14171A' },
+    warning: { main: tokens.status.warning, contrastText: '#14171A' },
+    error: { main: tokens.status.error, contrastText: '#14171A' },
+    info: { main: tokens.status.info, contrastText: '#14171A' },
+    background: {
+      default: tokens.backdrop.base,
+      paper: tokens.surface.glass,
+    },
+    text: {
+      primary: tokens.text.primary,
+      secondary: tokens.text.secondary,
+      disabled: tokens.text.disabled,
+    },
+    divider: tokens.hairline,
+  },
+
+  shape: { borderRadius: tokens.radius.md },
+
+  typography: {
+    fontFamily: FONT_STACK,
+    h4: { fontFamily: DISPLAY_STACK, fontSize: '1.75rem', fontWeight: 600, letterSpacing: '-0.02em' },
+    h5: { fontFamily: DISPLAY_STACK, fontSize: '1.25rem', fontWeight: 600, letterSpacing: '-0.015em' },
+    h6: { fontFamily: DISPLAY_STACK, fontSize: '1rem', fontWeight: 600, letterSpacing: '-0.01em' },
+    subtitle1: { fontSize: '0.9375rem', fontWeight: 550 },
+    subtitle2: { fontSize: '0.8125rem', fontWeight: 600, color: tokens.text.secondary },
+    body1: { fontSize: '0.9375rem' },
+    body2: { fontSize: '0.8125rem' },
+    caption: { fontSize: '0.75rem' },
+    button: { fontWeight: 550, letterSpacing: 0 },
+  },
+
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        html: { WebkitFontSmoothing: 'antialiased', MozOsxFontSmoothing: 'grayscale' },
+        body: {
+          backgroundColor: tokens.backdrop.base,
+          overflow: 'hidden',
+        },
+        '::selection': { background: alpha(tokens.accent, 0.32) },
+        // Thin overlay scrollbars — a large part of the macOS impression.
+        '*::-webkit-scrollbar': { width: 10, height: 10 },
+        '*::-webkit-scrollbar-track': { background: 'transparent' },
+        '*::-webkit-scrollbar-corner': { background: 'transparent' },
+        '*::-webkit-scrollbar-thumb': {
+          background: 'rgba(255, 255, 255, 0.18)',
+          borderRadius: 8,
+          border: '3px solid transparent',
+          backgroundClip: 'content-box',
+        },
+        '*::-webkit-scrollbar-thumb:hover': {
+          background: 'rgba(255, 255, 255, 0.30)',
+          backgroundClip: 'content-box',
+          border: '3px solid transparent',
+        },
+        '@media (prefers-reduced-motion: reduce)': {
+          '*': {
+            animationDuration: '0.01ms !important',
+            transitionDuration: '0.01ms !important',
+          },
+        },
+      },
+    },
+
+    MuiPaper: {
+      defaultProps: { elevation: 0 },
+      styleOverrides: {
+        root: glassSurface(),
+        outlined: { boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.08)' },
+      },
+    },
+
+    MuiButton: {
+      defaultProps: { disableElevation: true },
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          borderRadius: tokens.radius.sm + 2,
+          boxShadow: 'none',
+          paddingInline: 16,
+          transition: transition(),
+          '&:hover': { boxShadow: 'none' },
+        },
+        sizeLarge: { paddingInline: 22, paddingBlock: 9, fontSize: '0.9375rem' },
+        contained: ({ theme: t, ownerState }) => {
+          const main = paletteColor(t, ownerState.color) ?? tokens.accent;
+          return {
+            background: main,
+            color: '#14171A',
+            '&:hover': { background: alpha(main, 0.86) },
+            '&.Mui-disabled': {
+              background: tokens.surface.glassLo,
+              color: tokens.text.disabled,
+            },
+          };
+        },
+        outlined: {
+          borderColor: tokens.hairlineStrong,
+          color: tokens.text.primary,
+          background: tokens.surface.glassLo,
+          '&:hover': {
+            borderColor: tokens.hairlineStrong,
+            background: tokens.surface.glassHi,
+          },
+        },
+        text: {
+          color: tokens.text.secondary,
+          '&:hover': { background: tokens.surface.glassLo, color: tokens.text.primary },
+        },
+      },
+    },
+
+    MuiIconButton: {
+      styleOverrides: {
+        root: {
+          color: tokens.text.secondary,
+          borderRadius: tokens.radius.sm,
+          transition: transition(),
+          '&:hover': { background: tokens.surface.glassHi, color: tokens.text.primary },
+        },
+      },
+    },
+
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          background: tokens.surface.glassLo,
+          borderRadius: tokens.radius.sm + 2,
+          transition: transition(['background-color', 'box-shadow']),
+          '& .MuiOutlinedInput-notchedOutline': {
+            borderColor: tokens.hairline,
+            transition: transition(['border-color']),
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: tokens.hairlineStrong },
+          '&.Mui-focused': {
+            background: tokens.surface.glass,
+            boxShadow: `0 0 0 3px ${tokens.accentSofter}`,
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderWidth: 1,
+            borderColor: alpha(tokens.accent, 0.55),
+          },
+        },
+        input: { padding: '12px 14px' },
+        inputSizeSmall: { padding: '8px 12px' },
+      },
+    },
+
+    MuiInputLabel: {
+      styleOverrides: {
+        root: {
+          color: tokens.text.secondary,
+          '&.Mui-focused': { color: tokens.accent },
+        },
+      },
+    },
+
+    MuiFormHelperText: {
+      styleOverrides: {
+        root: { marginLeft: 2, marginTop: 6, fontSize: '0.75rem', color: tokens.text.secondary },
+      },
+    },
+
+    MuiCheckbox: {
+      styleOverrides: {
+        root: {
+          color: tokens.text.disabled,
+          borderRadius: tokens.radius.sm,
+          '&.Mui-checked': { color: tokens.accent },
+          '&:hover': { background: tokens.surface.glassLo },
+        },
+      },
+    },
+
+    MuiChip: {
+      styleOverrides: {
+        root: ({ theme: t, ownerState }) => {
+          const main = paletteColor(t, ownerState.color);
+          const outlined = ownerState.variant === 'outlined';
+
+          if (!main) {
+            return {
+              borderRadius: tokens.radius.sm - 2,
+              fontWeight: 550,
+              fontSize: '0.75rem',
+              background: outlined ? 'transparent' : tokens.surface.glassLo,
+              border: `1px solid ${tokens.hairline}`,
+              color: tokens.text.secondary,
+            };
+          }
+
+          return {
+            borderRadius: tokens.radius.sm - 2,
+            fontWeight: 550,
+            fontSize: '0.75rem',
+            background: outlined ? 'transparent' : alpha(main, 0.16),
+            border: `1px solid ${alpha(main, outlined ? 0.38 : 0.24)}`,
+            color: main,
+            '& .MuiChip-icon': { color: main },
+            '&.MuiChip-clickable:hover': { background: alpha(main, 0.24) },
+          };
+        },
+      },
+    },
+
+    MuiAlert: {
+      styleOverrides: {
+        root: ({ theme: t, ownerState }) => {
+          const main = paletteColor(t, ownerState.severity) ?? tokens.status.info;
+          return {
+            borderRadius: tokens.radius.md,
+            background: alpha(main, 0.12),
+            backdropFilter: tokens.blur.panel,
+            WebkitBackdropFilter: tokens.blur.panel,
+            border: `1px solid ${alpha(main, 0.28)}`,
+            color: tokens.text.primary,
+            '& .MuiAlert-icon': { color: main },
+          };
+        },
+      },
+    },
+
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          ...glassSurface({ radius: tokens.radius.sm, background: 'rgba(28, 32, 36, 0.92)' }),
+          fontSize: '0.75rem',
+          padding: '6px 10px',
+          color: tokens.text.primary,
+        },
+        arrow: { color: 'rgba(28, 32, 36, 0.92)' },
+      },
+    },
+
+    MuiAccordion: {
+      defaultProps: { disableGutters: true, elevation: 0 },
+      styleOverrides: {
+        root: {
+          ...glassSurface(),
+          marginBottom: 12,
+          overflow: 'hidden',
+          '&::before': { display: 'none' },
+          '&.Mui-expanded': { marginBottom: 12 },
+        },
+      },
+    },
+
+    MuiAccordionSummary: {
+      styleOverrides: {
+        root: {
+          minHeight: 56,
+          padding: '0 20px',
+          transition: transition(['background-color']),
+          '&:hover': { background: tokens.surface.glassLo },
+        },
+        content: { margin: '14px 0' },
+        expandIconWrapper: { color: tokens.text.secondary },
+      },
+    },
+
+    MuiAccordionDetails: {
+      styleOverrides: { root: { padding: '4px 20px 20px' } },
+    },
+
+    MuiTableCell: {
+      styleOverrides: {
+        root: { borderBottom: `1px solid ${tokens.hairline}` },
+        head: {
+          background: 'rgba(20, 23, 26, 0.82)',
+          backdropFilter: tokens.blur.bar,
+          WebkitBackdropFilter: tokens.blur.bar,
+          color: tokens.text.secondary,
+          fontWeight: 600,
+          fontSize: '0.6875rem',
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+        },
+      },
+    },
+
+    MuiTableRow: {
+      styleOverrides: {
+        root: {
+          transition: transition(['background-color']),
+          '&.MuiTableRow-hover:hover': { background: tokens.surface.glassLo },
+        },
+      },
+    },
+
+    MuiTableSortLabel: {
+      styleOverrides: {
+        root: {
+          '&.Mui-active': { color: tokens.accent },
+          '&.Mui-active .MuiTableSortLabel-icon': { color: `${tokens.accent} !important` },
+        },
+      },
+    },
+
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: { height: 3, borderRadius: 999, background: tokens.surface.glassHi },
+        bar: { borderRadius: 999, background: tokens.accent },
+      },
+    },
+
+    MuiSlider: {
+      styleOverrides: {
+        root: { color: tokens.accent },
+        rail: { background: tokens.surface.glassHi, opacity: 1 },
+        thumb: {
+          '&:hover, &.Mui-focusVisible': { boxShadow: `0 0 0 6px ${tokens.accentSofter}` },
+        },
+      },
+    },
+
+    MuiMenu: {
+      styleOverrides: {
+        paper: glassSurface({ radius: tokens.radius.md, blur: tokens.blur.bar, background: 'rgba(28, 32, 36, 0.88)' }),
+        list: { padding: 6 },
+      },
+    },
+
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          borderRadius: tokens.radius.sm - 2,
+          fontSize: '0.875rem',
+          transition: transition(['background-color']),
+          '&.Mui-selected': { background: tokens.accentSoft, color: tokens.accent },
+          '&.Mui-selected:hover': { background: tokens.accentSoft },
+        },
+      },
+    },
+
+    MuiPopover: {
+      styleOverrides: {
+        paper: glassSurface({ radius: tokens.radius.md, blur: tokens.blur.bar, background: 'rgba(28, 32, 36, 0.88)' }),
+      },
+    },
+
+    MuiListItemButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: tokens.radius.sm,
+          transition: transition(),
+          '&.Mui-selected': { background: tokens.accentSoft },
+          '&.Mui-selected:hover': { background: tokens.accentSoft },
+        },
+      },
+    },
+
+    MuiDivider: {
+      styleOverrides: { root: { borderColor: tokens.hairline } },
+    },
+
+    MuiStepConnector: {
+      styleOverrides: {
+        line: { borderColor: tokens.hairline },
+      },
+    },
+
+    MuiSnackbarContent: {
+      styleOverrides: { root: glassSurface({ radius: tokens.radius.md }) },
+    },
+
+    MuiCircularProgress: {
+      styleOverrides: { root: { color: tokens.accent } },
+    },
+  },
+});
+
+export { tokens, glassSurface, sunkenSurface };
+export default theme;

--- a/ui/src/theme/tokens.js
+++ b/ui/src/theme/tokens.js
@@ -1,0 +1,81 @@
+/**
+ * Design tokens for the glass UI.
+ *
+ * Every colour, radius and timing in the renderer resolves here. Components
+ * should not hardcode colour values — import from this file or use the
+ * helpers in `glass.js`.
+ */
+
+export const tokens = {
+  // Painted backdrop. The window itself is opaque; this gradient is what the
+  // translucent surfaces blur against.
+  //
+  // CS2 palette: neutral gunmetal, amber accent. The washes stay faint on
+  // purpose — CS2 menus are near-neutral and let the orange do the work.
+  backdrop: {
+    base: '#14171A',
+    end: '#1C2024',
+    washes: [
+      'radial-gradient(1200px 620px at 12% -12%, rgba(222, 155, 53, 0.10), transparent 62%)',
+      'radial-gradient(900px 520px at 96% 4%, rgba(94, 152, 217, 0.06), transparent 58%)',
+      'radial-gradient(760px 760px at 62% 112%, rgba(222, 155, 53, 0.05), transparent 60%)',
+    ],
+  },
+
+  surface: {
+    glass: 'rgba(255, 255, 255, 0.055)',
+    glassHi: 'rgba(255, 255, 255, 0.08)',
+    glassLo: 'rgba(255, 255, 255, 0.03)',
+    sunken: 'rgba(0, 0, 0, 0.30)',
+    sunkenDeep: 'rgba(0, 0, 0, 0.46)',
+  },
+
+  hairline: 'rgba(255, 255, 255, 0.09)',
+  hairlineStrong: 'rgba(255, 255, 255, 0.14)',
+
+  text: {
+    primary: '#E8EAEC',
+    secondary: '#98A0A8',
+    disabled: '#5E666E',
+  },
+
+  // CS2 amber.
+  accent: '#DE9B35',
+  accentSoft: 'rgba(222, 155, 53, 0.16)',
+  accentSofter: 'rgba(222, 155, 53, 0.10)',
+
+  // Drawn from CS2's own signalling: T yellow, CT blue, bomb red.
+  status: {
+    success: '#8CC63F',
+    warning: '#DEB93F',
+    error: '#EB4B4B',
+    info: '#5E98D9',
+  },
+
+  // `saturate` before `blur` is what separates glass from a grey wash.
+  blur: {
+    panel: 'saturate(180%) blur(24px)',
+    bar: 'saturate(180%) blur(30px)',
+  },
+
+  // Tighter than the Apple idiom — CS2's chrome is closer to square.
+  radius: {
+    sm: 6,
+    md: 8,
+    lg: 10,
+    xl: 14,
+  },
+
+  motion: {
+    easing: 'cubic-bezier(0.32, 0.72, 0, 1)',
+    duration: 160,
+  },
+
+  titleBarHeight: 44,
+  sidebarWidth: 248,
+};
+
+export const transition = (properties = ['background-color', 'border-color', 'color', 'transform', 'box-shadow']) =>
+  properties
+    .map((property) => `${property} ${tokens.motion.duration}ms ${tokens.motion.easing}`)
+    .join(', ');


### PR DESCRIPTION
Replace the stock MUI dark theme with a token-driven glass design system and rebuild the app shell.

- Add ui/src/theme: tokens.js as the single colour source, glass.js with glassSurface/sunkenSurface helpers, and a theme with per-component overrides. Palette follows CS2: gunmetal backdrop, amber accent, T yellow / CT blue / bomb red for status.
- Add ui/src/components/shell: painted backdrop, draggable glass title bar with a running-command indicator, redesigned sidebar, and a shared PageHeader replacing the header block duplicated across five pages.
- Frameless window via titleBarStyle hidden + titleBarOverlay, so Windows still draws its caption buttons and snap layouts keep working.
- Drop the Google Fonts request for a system stack, so the app renders identically offline.
- Retint Timeline, PreviewPlayer and the log console off tokens instead of hardcoded hex; replace the save alert() in Music Editor with a snackbar.